### PR TITLE
Fix orbital mechanics: axis orientation and marker behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ An interactive educational applet that demonstrates how Earth's orbital position
 ### Features
 
 - **Orbital View**: Visual representation of Earth's position around the sun throughout the year
-  - Shows day/night terminator on Earth
-  - Red marker indicates your selected latitude position
-  - Visualizes planet rotation in real-time
+  - **Yellow axis bar**: Shows Earth's rotational axis - maintains constant orientation in space (this is what causes seasons!)
+  - **Day/night terminator**: Dark overlay shows the hemisphere facing away from the sun
+  - **Red marker**: Indicates your selected latitude at the subsolar meridian (only moves with latitude slider)
+  - **Cyan dot**: Rotation indicator on the equator (shows planet rotation as you change the rotation angle)
 - **Interactive Controls**:
   - Orbital Position slider: Choose any day of the year (0-360°)
   - Latitude selector: Pick any latitude from South Pole (-90°) to North Pole (90°)

--- a/planet-simulator.html
+++ b/planet-simulator.html
@@ -432,15 +432,15 @@
 
             orbitalCtx.restore();
 
-            // Draw selected latitude point
+            // Draw selected latitude point (at the subsolar/noon meridian)
+            // The red dot only shows LATITUDE, not rotation
             orbitalCtx.save();
             orbitalCtx.translate(earthX, earthY);
 
-            // Rotate for planet's rotation angle and tilt
-            const totalRotation = sunDirection + (rotationAngle * DEG_TO_RAD);
-            orbitalCtx.rotate(totalRotation);
+            // Rotate to align with sun (but NOT with planet rotation)
+            orbitalCtx.rotate(sunDirection);
 
-            // Position marker at selected latitude
+            // Position marker at selected latitude on the day side
             // Latitude affects vertical position on the visible disk
             const latRadius = 25 * Math.cos(latitude * DEG_TO_RAD);
             const latY = -25 * Math.sin(latitude * DEG_TO_RAD);
@@ -448,22 +448,41 @@
             // Draw marker
             orbitalCtx.fillStyle = '#FF6B6B';
             orbitalCtx.strokeStyle = '#FFF';
-            orbitalCtx.lineWidth = 1.5;
+            orbitalCtx.lineWidth = 2;
             orbitalCtx.beginPath();
-            orbitalCtx.arc(latRadius, latY, 4, 0, 2 * Math.PI);
+            orbitalCtx.arc(latRadius, latY, 5, 0, 2 * Math.PI);
             orbitalCtx.fill();
             orbitalCtx.stroke();
 
             orbitalCtx.restore();
 
-            // Draw axis tilt
-            const tiltAngle = (orbitalAngle + 90) * DEG_TO_RAD; // Axis points in consistent direction
+            // Draw rotation indicator on the equator to show planet rotation
+            orbitalCtx.save();
+            orbitalCtx.translate(earthX, earthY);
+
+            // Rotate by sun direction PLUS rotation angle
+            orbitalCtx.rotate(sunDirection + (rotationAngle * DEG_TO_RAD));
+
+            // Draw small indicator on equator
+            orbitalCtx.fillStyle = '#00D9FF';
+            orbitalCtx.strokeStyle = '#FFF';
+            orbitalCtx.lineWidth = 1.5;
+            orbitalCtx.beginPath();
+            orbitalCtx.arc(25, 0, 3, 0, 2 * Math.PI);
+            orbitalCtx.fill();
+            orbitalCtx.stroke();
+
+            orbitalCtx.restore();
+
+            // Draw axis tilt - FIXED orientation in space (this is key to seasons!)
+            // Axis always points in the same direction in the inertial frame
+            const axisAngleInSpace = (90 - AXIAL_TILT) * DEG_TO_RAD; // Fixed angle
             const axisLength = 40;
-            const axisDx = axisLength * Math.cos(tiltAngle + (90 - AXIAL_TILT) * DEG_TO_RAD);
-            const axisDy = axisLength * Math.sin(tiltAngle + (90 - AXIAL_TILT) * DEG_TO_RAD);
+            const axisDx = axisLength * Math.cos(axisAngleInSpace);
+            const axisDy = axisLength * Math.sin(axisAngleInSpace);
 
             orbitalCtx.strokeStyle = '#FFD700';
-            orbitalCtx.lineWidth = 2;
+            orbitalCtx.lineWidth = 3;
             orbitalCtx.beginPath();
             orbitalCtx.moveTo(earthX - axisDx, earthY - axisDy);
             orbitalCtx.lineTo(earthX + axisDx, earthY + axisDy);


### PR DESCRIPTION
Corrected fundamental physics errors in the visualization:

1. **Fixed axis orientation in space**:
   - Earth's rotational axis now maintains a CONSTANT orientation in the inertial reference frame as it orbits the sun
   - This is the actual cause of seasons - the axis points in the same direction in space, so different hemispheres tilt toward/away from the sun at different times of year
   - Changed from: axis angle depends on orbital position
   - Changed to: axis angle is fixed at 23.5° from vertical

2. **Fixed latitude marker (red dot)**:
   - Red dot now ONLY indicates latitude selection
   - Does NOT rotate with planet rotation angle
   - Always positioned at the subsolar meridian (noon position)
   - Only the latitude slider moves the red dot

3. **Added rotation indicator (cyan dot)**:
   - New cyan dot on the equator rotates with rotation angle
   - Shows the planet's daily rotation clearly
   - Helps visualize how different parts of Earth face the sun

The rotation angle slider now properly rotates the planet around its fixed axis, affecting what you see in the sky view, while the orbital position determines the seasonal tilt toward/away from the sun.